### PR TITLE
Version 1.18

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -93,19 +93,22 @@ var Hangman = {
 	wordBankWords: [],
 	wordBankDefs: [],
 	cacheWords: function() {
-		// cache 30 words at a time
-		if(Hangman.wordBankWords.length < 50) {
-			var w = Word_List.getRandomWord();
-			Hangman.getDef(w, true);
-			setTimeout( function() {
-				if(Hangman.cacheDef != "") {
-					// found a word with a definition!
-					Hangman.wordBankWords.push(w);
-					Hangman.wordBankDefs.push(Hangman.cacheDef);
-				}
-			}, 500);
+		var online = navigator.onLine;
+		if(online) {
+			// cache limited number of words
+			if(Hangman.wordBankWords.length < 50) {
+				var w = Word_List.getRandomWord();
+				Hangman.getDef(w, true);
+				setTimeout( function() {
+					if(Hangman.cacheDef != "") {
+						// found a word with a definition!
+						Hangman.wordBankWords.push(w);
+						Hangman.wordBankDefs.push(Hangman.cacheDef);
+					}
+				}, 500);
+			}
+			Hangman.saveWordBank();
 		}
-		Hangman.saveWordBank();
 		document.getElementById("nav-cached-words").innerHTML = "Cached Words: " + Hangman.wordBankWords.length;
 	},
 	saveWordBank: function () {
@@ -180,6 +183,7 @@ var Hangman = {
 			});
 		} else {
 			Hangman.cacheDef = "";
+			Hangman.def = "User offline. Reconnect to get definitions.";
 		}
 	},
 	isGuessedLetter: function(ltr) {
@@ -255,7 +259,6 @@ var Hangman = {
 		}
 	},
 	beginGame: function() {
-		//Nav.close();
 		fadeOutEffect("end-screen");
 		fadeInEffect("game-screen");
 		Hangman.def = "";
@@ -370,10 +373,6 @@ var svgAnimator = {
 		}
 	}
 };
-
-function isLetter(str) {
-	return str.length === 1 && str.match(/[a-z]/i);
-}
 
 function setStyle(s) {
 	document.getElementById("day-night-stylesheet").setAttribute("href", "assets/css/" + s + ".css");

--- a/index.html
+++ b/index.html
@@ -47,13 +47,13 @@
 		<a id="difficulty" href="javascript:Hangman.toggleDifficultyCheck();">Easy</a>
 		<a href="javascript:Hangman.beginGame()">New Game</a>
 		<a href="javascript:Hangman.emptyCache()">Empty Cache</a>
-		<a href="https://github.com/kylesureline">GitHub <i class="fas fa-external-link-alt"></i></a>
+		<a href="https://github.com/kylesureline/hangapp">GitHub <i class="fas fa-external-link-alt"></i></a>
 		<a href="mailto:kyle@kylesureline.com">Contact</a>
 		<div id="nav-info">
 			<span id="nav-wins"></span>
 			<span id="nav-losses"></span>
 			<span id="nav-cached-words"></span>
-			<span id="version">v1.17</span>
+			<span id="version">v1.18</span>
 		</div>
 	</div>
 	<div id="main">

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,12 @@ A simple Hangman game, built as a Progressive Web App. Playable [here](https://k
 
 ### Changelog
 
+**Version 1.18**
+
+- Change: GitHub link points to this repo now, rather than old one (duh!)
+- Fix: Only cache words if online (double duh!)
+- Change: Instead of a blank definition, provide a message alerting the user to reconnect (if they are offline) to get definitions
+
 **Version 1.17**
 
 - Change: Resize link to M-W.com

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'v1.17';
+const CACHE_NAME = 'v1.18';
 
 var urlsToCache = [
 	'index.html',


### PR DESCRIPTION
- Change: GitHub link points to this repo now, rather than old one (duh!)
- Fix: Only cache words if online (double duh!)
- Change: Instead of a blank definition, provide a message alerting the user to reconnect (if they are offline) to get definitions